### PR TITLE
Add v6_create_list_query utility for Create List-style queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 - **SierraRESTClient** (`sierra_rest_client.py`): Core HTTP client with sync (`request()`) and async (`async_request()`) methods. Handles token management, 401 refresh, and 5xx retries.
 - **SierraDateTime/SierraDate** (`sierra_datetime.py`): Datetime wrappers ensuring Sierra API-compatible formatting (UTC, no microseconds, 'Z' suffix).
 - **get_max_record_id** (`utils.py`): Utility to find maximum valid record ID using exponential/binary search.
+- **v6_create_list_query** (`utils.py`): Async utility to execute Create List-style JSON queries and fetch full record data with concurrent requests.
 
 ## Development Commands
 
@@ -65,6 +66,7 @@ Tests use `pytest` with `respx` for HTTP mocking. Run with `uv run pytest`.
 
 ### Features
 
+- [x] Add `v6_create_list_query()` for Create List-style queries with concurrent record fetching
 - [ ] Add async version of `get_max_record_id()`
 - [ ] Add convenience methods (`get()`, `post()`, etc.)
 - [ ] Consider rate limiting support

--- a/sierra_ils_utils/__init__.py
+++ b/sierra_ils_utils/__init__.py
@@ -2,7 +2,7 @@ from importlib.metadata import version, PackageNotFoundError
 
 from .sierra_rest_client import SierraRESTClient
 from .sierra_datetime import SierraDateTime, SierraDate
-from .utils import get_max_record_id
+from .utils import get_max_record_id, v6_create_list_query
 
 # Get version from package metadata
 try:
@@ -20,4 +20,5 @@ __all__ = [
     "SierraDateTime",
     "SierraDate",
     "get_max_record_id",
+    "v6_create_list_query",
 ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
 import pytest
-from unittest.mock import MagicMock
-from sierra_ils_utils.utils import get_max_record_id
+import respx
+from httpx import Response
+from unittest.mock import MagicMock, AsyncMock
+from sierra_ils_utils import SierraRESTClient
+from sierra_ils_utils.utils import get_max_record_id, v6_create_list_query
 
 
 class TestGetMaxRecordId:
@@ -151,3 +154,284 @@ class TestGetMaxRecordId:
         assert call_args[1]['params']['limit'] == 25
         assert call_args[1]['params']['fields'] == 'id'
         assert call_args[1]['params']['id'] == '[500,]'
+
+
+class TestV6CreateListQuery:
+    """Tests for the v6_create_list_query utility function."""
+
+    @pytest.mark.asyncio
+    async def test_basic_query_returns_records(self):
+        """
+        Test that a basic query returns hydrated records.
+        """
+        base_url = "https://catalog.library.org/iii/sierra-api/v6/"
+        token_url = f"{base_url}token"
+        query_url = f"{base_url}items/query"
+        item1_url = f"{base_url}v6/items/12345"
+        item2_url = f"{base_url}v6/items/12346"
+
+        with respx.mock:
+            # Mock token endpoint
+            respx.post(token_url).mock(
+                return_value=Response(200, json={"access_token": "FAKE_TOKEN", "expires_in": 3600})
+            )
+
+            # Mock query endpoint - returns links to items
+            respx.post(query_url).mock(
+                return_value=Response(200, json={
+                    "total": 2,
+                    "entries": [
+                        {"link": item1_url},
+                        {"link": item2_url},
+                    ]
+                })
+            )
+
+            # Mock individual item fetches
+            respx.get(item1_url).mock(
+                return_value=Response(200, json={"id": "12345", "barcode": "A000001"})
+            )
+            respx.get(item2_url).mock(
+                return_value=Response(200, json={"id": "12346", "barcode": "A000002"})
+            )
+
+            client = SierraRESTClient(
+                base_url=base_url,
+                client_id="client_id",
+                client_secret="client_secret"
+            )
+
+            query = {
+                "queries": [{
+                    "target": {"record": {"type": "item"}, "field": {"tag": "b"}},
+                    "expr": {"op": "in", "operands": ["A000001", "A000002"]}
+                }]
+            }
+
+            results = await v6_create_list_query(
+                client, "items", query,
+                fields="id,barcode"
+            )
+
+            assert len(results) == 2
+            barcodes = {r["barcode"] for r in results}
+            assert barcodes == {"A000001", "A000002"}
+
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_empty_list(self):
+        """
+        Test that a query with no matches returns an empty list.
+        """
+        base_url = "https://catalog.library.org/iii/sierra-api/v6/"
+        token_url = f"{base_url}token"
+        query_url = f"{base_url}items/query"
+
+        with respx.mock:
+            respx.post(token_url).mock(
+                return_value=Response(200, json={"access_token": "FAKE_TOKEN", "expires_in": 3600})
+            )
+
+            respx.post(query_url).mock(
+                return_value=Response(200, json={"total": 0, "entries": []})
+            )
+
+            client = SierraRESTClient(
+                base_url=base_url,
+                client_id="client_id",
+                client_secret="client_secret"
+            )
+
+            query = {"queries": []}
+            results = await v6_create_list_query(client, "items", query)
+
+            assert results == []
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_pagination_fetches_all_records(self):
+        """
+        Test that pagination works correctly when query returns more than query_limit.
+        """
+        base_url = "https://catalog.library.org/iii/sierra-api/v6/"
+        token_url = f"{base_url}token"
+        query_url = f"{base_url}items/query"
+
+        with respx.mock:
+            respx.post(token_url).mock(
+                return_value=Response(200, json={"access_token": "FAKE_TOKEN", "expires_in": 3600})
+            )
+
+            # First query returns 2 items (at limit)
+            # Second query returns 1 item (less than limit, indicating end)
+            query_route = respx.post(query_url)
+            query_route.side_effect = [
+                Response(200, json={
+                    "entries": [
+                        {"link": f"{base_url}v6/items/1"},
+                        {"link": f"{base_url}v6/items/2"},
+                    ]
+                }),
+                Response(200, json={
+                    "entries": [
+                        {"link": f"{base_url}v6/items/3"},
+                    ]
+                }),
+            ]
+
+            # Mock individual item fetches
+            respx.get(f"{base_url}v6/items/1").mock(
+                return_value=Response(200, json={"id": "1"})
+            )
+            respx.get(f"{base_url}v6/items/2").mock(
+                return_value=Response(200, json={"id": "2"})
+            )
+            respx.get(f"{base_url}v6/items/3").mock(
+                return_value=Response(200, json={"id": "3"})
+            )
+
+            client = SierraRESTClient(
+                base_url=base_url,
+                client_id="client_id",
+                client_secret="client_secret"
+            )
+
+            query = {"queries": []}
+            results = await v6_create_list_query(
+                client, "items", query,
+                query_limit=2  # Small limit to trigger pagination
+            )
+
+            assert len(results) == 3
+            ids = {r["id"] for r in results}
+            assert ids == {"1", "2", "3"}
+
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_endpoint_normalization(self):
+        """
+        Test that endpoint with slashes is normalized correctly.
+        """
+        base_url = "https://catalog.library.org/iii/sierra-api/v6/"
+        token_url = f"{base_url}token"
+        query_url = f"{base_url}bibs/query"
+        bib_url = f"{base_url}v6/bibs/999"
+
+        with respx.mock:
+            respx.post(token_url).mock(
+                return_value=Response(200, json={"access_token": "FAKE_TOKEN", "expires_in": 3600})
+            )
+
+            respx.post(query_url).mock(
+                return_value=Response(200, json={
+                    "entries": [{"link": bib_url}]
+                })
+            )
+
+            respx.get(bib_url).mock(
+                return_value=Response(200, json={"id": "999", "title": "Test Book"})
+            )
+
+            client = SierraRESTClient(
+                base_url=base_url,
+                client_id="client_id",
+                client_secret="client_secret"
+            )
+
+            # Test with leading/trailing slashes
+            query = {"queries": []}
+            results = await v6_create_list_query(client, "/bibs/", query, fields="id,title")
+
+            assert len(results) == 1
+            assert results[0]["title"] == "Test Book"
+
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_concurrency_parameter(self):
+        """
+        Test that concurrency parameter is respected (verifies semaphore is used).
+        """
+        base_url = "https://catalog.library.org/iii/sierra-api/v6/"
+        token_url = f"{base_url}token"
+        query_url = f"{base_url}items/query"
+
+        with respx.mock:
+            respx.post(token_url).mock(
+                return_value=Response(200, json={"access_token": "FAKE_TOKEN", "expires_in": 3600})
+            )
+
+            # Return 10 items
+            entries = [{"link": f"{base_url}v6/items/{i}"} for i in range(10)]
+            respx.post(query_url).mock(
+                return_value=Response(200, json={"entries": entries})
+            )
+
+            # Mock all item fetches
+            for i in range(10):
+                respx.get(f"{base_url}v6/items/{i}").mock(
+                    return_value=Response(200, json={"id": str(i)})
+                )
+
+            client = SierraRESTClient(
+                base_url=base_url,
+                client_id="client_id",
+                client_secret="client_secret"
+            )
+
+            query = {"queries": []}
+            results = await v6_create_list_query(
+                client, "items", query,
+                concurrency=2  # Low concurrency
+            )
+
+            assert len(results) == 10
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_extra_params_passed_to_get(self):
+        """
+        Test that extra **params are passed through to the GET requests.
+        """
+        base_url = "https://catalog.library.org/iii/sierra-api/v6/"
+        token_url = f"{base_url}token"
+        query_url = f"{base_url}items/query"
+        item_url = f"{base_url}v6/items/123"
+
+        with respx.mock:
+            respx.post(token_url).mock(
+                return_value=Response(200, json={"access_token": "FAKE_TOKEN", "expires_in": 3600})
+            )
+
+            respx.post(query_url).mock(
+                return_value=Response(200, json={
+                    "entries": [{"link": item_url}]
+                })
+            )
+
+            # Capture the GET request to verify params
+            get_route = respx.get(item_url).mock(
+                return_value=Response(200, json={"id": "123"})
+            )
+
+            client = SierraRESTClient(
+                base_url=base_url,
+                client_id="client_id",
+                client_secret="client_secret"
+            )
+
+            query = {"queries": []}
+            await v6_create_list_query(
+                client, "items", query,
+                fields="id,barcode",
+                suppressed="false"  # Extra param
+            )
+
+            # Check that the GET request included the extra param
+            assert get_route.called
+            request = get_route.calls[0].request
+            assert b"suppressed=false" in request.url.query
+
+            await client.aclose()


### PR DESCRIPTION
## Summary

- Adds `v6_create_list_query()` async utility function that simplifies the common two-phase pattern of querying records via the Sierra API `/query` endpoint and then fetching full record details
- Handles pagination automatically when queries return more than `query_limit` records
- Fetches full record data concurrently with configurable `concurrency` parameter (default: 5)
- Passes through extra `**params` to GET requests for flexibility

## Example Usage

```python
from sierra_ils_utils import v6_create_list_query

query = {
    "queries": [{
        "target": {"record": {"type": "item"}, "field": {"tag": "b"}},
        "expr": {"op": "in", "operands": ["A000001", "A000002"]}
    }]
}

items = await v6_create_list_query(
    client, "items", query,
    fields="id,barcode,status,location",
    concurrency=5
)
```

## Test plan

- [x] Added tests for basic query returning records
- [x] Added tests for empty query results
- [x] Added tests for pagination handling
- [x] Added tests for endpoint normalization (handles leading/trailing slashes)
- [x] Added tests for concurrency parameter
- [x] Added tests for extra params passthrough
- [x] All 41 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)