### PR TITLE
docs: Phase 2a — Quirks-Catalog Diátaxis resolution + prose graduations

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,10 +19,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -45,7 +45,7 @@ jobs:
         run: bash scripts/check-docs-clean.sh site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/docs/explanation/discover-quirks-yourself.md
+++ b/docs/explanation/discover-quirks-yourself.md
@@ -1,0 +1,38 @@
+# Discovering quirks yourself
+
+You don't have to take this catalog on faith. Every entry here started as a behavior
+someone observed, then confirmed with a deliberately safe probe — and you can confirm
+any of them on your own deployment the same way. This page is about the *method*: how
+to learn what Sierra actually does without endangering real data.
+
+## The principle: observe without meaningfully mutating
+
+The whole approach rests on one idea — arrange a write whose *content* effect is nil
+while you watch what the system does *around* it. If the data you send back is identical
+to what was already there, anything that changed afterward was the system's doing, not
+yours. That's what makes side effects visible in isolation.
+
+## How the safe probes work, and why
+
+- **Test against a sandbox, or pick clearly inactive records.** A test/sandbox Sierra is
+  ideal; failing that, records you can prove are dormant keep the blast radius near zero.
+- **Probe with identical-data PUTs and intentionally malformed PUTs.** An identical-data
+  PUT changes no content but still triggers whatever side effects a write carries — so it
+  isolates them. A malformed PUT (one Sierra will reject) lets you confirm the
+  *validate-before-write* boundary: nothing should move when the write fails.
+- **Hash the content fields before and after.** Equal hashes prove the payload is
+  unchanged while you watch which housekeeping fields Sierra moved on its own. This is how
+  the "an identical PUT still bumps four timestamps" finding was pinned down.
+- **Cross-check against the database read-only.** If you have SQL access, comparing the
+  API's view against the underlying rows is how you learn things like "the API `id` is the
+  record number, not the primary key."
+
+The reason these probes are trustworthy is the model in
+[Why writes have side effects](sierra-rest-thin-projection.md): because the API writes
+straight to the database, an identical-data PUT exercises the *real* write path, so the
+side effects you observe are the real ones — not an artifact of a test double.
+
+## A runnable harness is planned
+
+A deployment-agnostic, sanitized version of this probe harness is planned for a later
+phase of this guide, so you can run the confirmations rather than hand-roll them.

--- a/docs/explanation/sierra-rest-thin-projection.md
+++ b/docs/explanation/sierra-rest-thin-projection.md
@@ -54,5 +54,5 @@ came through REST rather than the Desktop client.
 
 - Reference: [Write semantics → derived projections](../reference/quirks/write-semantics.md)
   and [Side effects](../reference/quirks/side-effects.md) — the austere "what happens".
-<!-- The "How-to: Safely edit a record" bullet is appended here in Task 3, once that
-     page exists, to keep this commit's `mkdocs build --strict` link-clean. -->
+- How-to: [Safely edit a record (GET-modify-PUT)](../how-to/safe-get-modify-put.md) —
+  what to *do* about it.

--- a/docs/explanation/sierra-rest-thin-projection.md
+++ b/docs/explanation/sierra-rest-thin-projection.md
@@ -1,0 +1,58 @@
+# Why writes have side effects: Sierra REST is a thin projection over the DB
+
+If a single mental model saves you from the write-side surprises in this guide, it's
+this one: **the Sierra REST API is a thin layer over the Sierra database, not a store
+with its own state.** It reads and writes the same underlying tables that the Desktop
+client and the SQL views see. Almost every "why does a write do *that*?" question
+follows from that one fact.
+
+## The model
+
+The API does not hold an independent copy of a record. On a read it *renders* a JSON
+view from the underlying rows; on a write it *applies* your changes back to those same
+rows and re-renders. There is no separate API-side representation that could behave
+differently from the database — which is exactly why the behaviors below are so
+stubborn: they aren't API conveniences that a flag could turn off, they're properties
+of the store.
+
+## What follows from it
+
+**The convenient top-level arrays are projections, not state.** `emails`, `phones`,
+`addresses`, and `names` are *rendered from* the underlying `varFields` on every read,
+and **re-rendered after every write**. They look like fields you could set, but they
+have no independent existence — which is why writing them behaves oddly and why
+comparing them before/after a write to ask "did anything else change?" always
+false-positives. The varFields are the real state.
+
+**A write is a write, even a byte-identical one.** Because your PUT is applied to the
+database rather than diffed against an API cache, a successful PUT moves the record's
+housekeeping bookkeeping — Updated Date, Revisions, PDATE, and Last Circ Activity
+(CIRCACTIVE) — *even when the payload matches what was already there*. There is no
+per-request opt-out because, at the storage layer, there is nothing to opt out of. A
+`GET` changes nothing, and a PUT that fails validation (`400`) changes nothing, for the
+same reason: only a successful write reaches the rows.
+
+**A REST PUT looks like two saves.** The Revisions counter moves by **2** per REST PUT
+but by **1** per Desktop save. The most economical explanation is that a REST write
+performs two internal saves — one for your payload and one for the API's own
+bookkeeping fields — each of which the store counts as a revision. You don't need the
+internals to be certain; the +2 is a reliable, if rough, forensic signal that a change
+came through REST rather than the Desktop client.
+
+## Why it matters to you
+
+- **Retention, purge, and dormancy workflows** that key off `activity_gmt` (CIRCACTIVE),
+  Updated Date, Revisions, or PDATE will see every touched record as "recently active."
+  If that's undesirable, skip records you'd rather not bump — you can't bump them
+  "quietly."
+- **Verification logic** must treat those four housekeeping fields, and the derived
+  top-level arrays, as expected-to-move. Compare the underlying varFields instead.
+- **Mirroring or caching Sierra** means respecting that the API is a window onto live
+  state, not a system of record you can treat as static between polls.
+
+## See also
+
+- Reference: [Write semantics → derived projections](../reference/quirks/write-semantics.md)
+  and [Side effects](../reference/quirks/side-effects.md) — the austere "what happens".
+<!-- The "How-to: Safely edit a record" bullet is appended here in Task 3, once that
+     page exists, to keep this commit's `mkdocs build --strict` link-clean. -->

--- a/docs/how-to/poll-for-changes.md
+++ b/docs/how-to/poll-for-changes.md
@@ -1,0 +1,93 @@
+# Poll for changed and deleted records
+
+**Goal:** keep a downstream copy of Sierra current by incrementally harvesting records
+that changed, and — separately — records that were deleted, without missing or
+double-counting any.
+
+You need **two** poll loops on **two** cursors. A `deleted=false` change poll structurally
+cannot see deletions (a deleted record just stops appearing), so deletions get their own
+loop. Both use keyset pagination, not `offset`.
+
+## 1. Poll for changes (windowed keyset pagination)
+
+Page through a change window by ascending `id`, advancing the cursor to `max(id) + 1`
+each page. Combine a time window and an id range in one query — they AND together — so you
+get the late-arriving-data safety of a time window with the gap/dup-free property of a
+seek cursor.
+
+```python
+def poll_changes(client, since, until, *, start_id=0, limit=2000):
+    cursor = start_id
+    while True:
+        url = f"bibs?deleted=false&updatedDate=[{since},{until}]&id=[{cursor},]&limit={limit}"
+        resp = client.request("GET", url)
+        if resp.status_code == 404:        # Sierra's "no records match" for a range query
+            break                          # treat 404 + code 107 as zero results, not an error
+        resp.raise_for_status()
+        entries = resp.json().get("entries", [])
+        if not entries:
+            break
+        yield from entries
+        if len(entries) < limit:           # short page => end of results (don't trust `total`)
+            break
+        cursor = entries[-1]["id"] + 1     # keyset advance; entries are ascending by id
+```
+
+Two traps this handles: a zero-match window returns **`404` + `code 107`**, not an empty
+list, so it's caught explicitly; and the end of results is a **short page**, not
+`total` (which reflects only the capped per-request count).
+
+## 2. Poll for deletions (separate cursor, day-granular)
+
+`deletedDate` is **date-only** (no time component), so the deletion cursor must be
+day-granular with a **≥1-day overlap** re-sweep. You'll re-see freshly deleted ids until
+the cursor passes their whole `deletedDate` day — so make the downstream action (e.g.
+tombstoning) **idempotent** and the overlap costs nothing.
+
+```python
+def poll_deletions(client, since_day, until_day, *, start_id=0, limit=2000):
+    cursor = start_id
+    while True:
+        url = f"bibs?deleted=true&deletedDate=[{since_day},{until_day}]&id=[{cursor},]&limit={limit}"
+        resp = client.request("GET", url)
+        if resp.status_code == 404:
+            break
+        resp.raise_for_status()
+        entries = resp.json().get("entries", [])
+        if not entries:
+            break
+        yield from entries
+        if len(entries) < limit:
+            break
+        cursor = entries[-1]["id"] + 1
+```
+
+Note the *deleted* variant returns `200 {"entries": []}` on an idle window where the
+*change* variant returns `404` — don't assume the two shapes behave the same; the `404`
+guard above is harmless either way.
+
+## 3. Reconcile periodically (catch what polls can't)
+
+Even with both loops, a record deleted outside your overlap window, or a poll that
+silently dropped, can leave a phantom-live row. Periodically **reconcile**: compare your
+live id set against Sierra's and tombstone the difference. Don't try to infer deletions
+from "an id I expected but didn't get back" in the change poll — that false-positives on
+suppressed / no-MARC records.
+
+## Verify
+
+- Run the change poll over a window you know contains edits; confirm it terminates on a
+  short page and re-running with the same cursor is idempotent.
+- Run the deletion poll over a window with a known deletion; confirm the id appears and
+  that re-running (overlap) doesn't double-tombstone.
+
+---
+
+**Underlying behavior (reference):**
+
+- [Change polling, ranges & pagination](../reference/quirks/change-polling.md) — the
+  `404`-on-empty, date-only `deletedDate`, ascending-`id` keyset, range-AND, ~2000 cap,
+  and `deleted=false`-hides-deletions entries.
+
+**For bulk MARC specifically:**
+[Bulk-export the full MARC catalog](bulk-export-marc.md)

--- a/docs/how-to/safe-get-modify-put.md
+++ b/docs/how-to/safe-get-modify-put.md
@@ -1,0 +1,85 @@
+# Safely edit a record (GET-modify-PUT)
+
+**Goal:** change one or more `varFields` on a patron (or bib/item) record without
+destroying the fields you didn't touch.
+
+A `PUT` that includes `varFields` **replaces the entire array** — every varField you omit
+is deleted. So you never construct a PUT body from scratch; you fetch the whole record,
+edit it in memory, and PUT the *complete* array back.
+
+## Before you start
+
+- A `SierraRESTClient` authenticated against your deployment.
+- The record number (`record_num`) of the record you're editing.
+
+## 1. GET the full record
+
+Use the bare-comma `fields=,` form to get **all** fields — without it you get a minimal
+response that's missing the varFields you need to preserve.
+
+```python
+resp = client.request("GET", f"patrons/{record_num}", params={"fields": ","})
+record = resp.json()
+varfields = record.get("varFields", [])
+```
+
+## 2. Modify varFields in memory
+
+Edit the list you fetched, leaving every entry you don't intend to change untouched. Drop
+any entry whose `content` is empty before sending — Sierra silently removes empty-content
+varFields on save, so pre-filtering keeps your before/after comparison honest.
+
+```python
+varfields = [vf for vf in varfields if vf.get("content")]   # drop empty-content entries
+# ... make your edits to varfields here ...
+```
+
+## 3. PUT only the mutable subset
+
+Send just `{"varFields": [...]}` — the complete array. Do **not** echo the whole GET
+response back: Sierra rejects ~9 read-only top-level fields (`id`, `homeLibrary`,
+`updatedDate`, `createdDate`, `deleted`, …) with `400 Invalid JSON : field(s) unknown`.
+
+```python
+resp = client.request("PUT", f"patrons/{record_num}", json={"varFields": varfields})
+```
+
+## 4. Check for 204, not 200
+
+A successful update returns **`204 No Content`** with no body. Don't call `.json()` on it.
+
+```python
+if resp.status_code == 204:
+    ...  # success
+elif resp.status_code == 404:
+    ...  # "ghost record": GET worked but PUT 404s — skip it, non-fatal
+else:
+    resp.raise_for_status()
+```
+
+## Gotchas this recipe already handles
+
+- **Full-array replacement** — step 1's `fields=,` + step 3's complete-array PUT is the
+  whole point; omitting a varField deletes it.
+- **Empty-content drop** — step 2 pre-filters so it doesn't surprise your verification.
+- **Read-only fields** — step 3 sends only `varFields`, avoiding the `400`.
+- **204 not 200** — step 4 checks the right status and never parses an empty body.
+- **Ghost records** — step 4 treats a PUT `404` after a successful GET as a non-fatal skip.
+- **Don't send top-level `phones`** — it *appends* instead of replacing; manage phone data
+  through varFields, which this recipe does by construction.
+
+## Verify
+
+After the PUT, GET the record again with `fields=,` and compare the **underlying
+varFields** — not the top-level `emails`/`phones`/`names` arrays, which Sierra re-renders
+on every write and will always look "changed".
+
+---
+
+**Underlying behavior (reference):**
+
+- [Write semantics → PUT varFields is full replacement](../reference/quirks/write-semantics.md)
+- [Reads & IDs → `fields=,` returns all fields](../reference/quirks/reads-and-ids.md)
+
+**Why this is necessary:**
+[Why writes have side effects](../explanation/sierra-rest-thin-projection.md)

--- a/docs/reference/quirks/change-polling.md
+++ b/docs/reference/quirks/change-polling.md
@@ -63,7 +63,7 @@ strictly after the previous page, with no gap and no overlap.
 
 **How to handle:** Prefer **keyset (seek) pagination** — `id=[<last_seen_id + 1>,]` — over `offset` for
 large or long-running sweeps. Offset pagination can drop or duplicate rows if the underlying set
-changes mid-sweep; an ascending-`id` seek cursor is gap/dup-free under concurrent inserts and deletes.
+changes mid-sweep; an ascending-`id` seek cursor is gap/dup-free under concurrent inserts and deletes. For the full polling loop, see [Poll for changed and deleted records](../../how-to/poll-for-changes.md).
 
 **How we know:** Page 1 (`id=[1000000,]`, limit 50) returned `1000001…1000051` ascending; page 2
 (`id=[1000052,]`) returned `1000052…` — strictly after page 1, with no gap or overlap.
@@ -121,7 +121,7 @@ therefore **never learns the record is gone** — it simply stops appearing, ind
 `deleted=true&deletedDate=[…]` poll on its own cursor** (mind its day granularity, above), and/or a
 periodic **id reconciliation** (compare your live id set against Sierra's) to catch the deletions the
 change poll structurally cannot see. Don't try to infer deletions from "an id I expected but didn't get
-back" in a change poll — that false-positives on suppressed / no-MARC records.
+back" in a change poll — that false-positives on suppressed / no-MARC records. The [Poll for changed and deleted records](../../how-to/poll-for-changes.md) recipe runs the required two-cursor pattern.
 
 **How we know:** A mirror built only on `deleted=false` incremental polls accrued server-deleted
 records as permanently-live rows; adding a `deletedDate` delete-poll plus an id reconcile was required

--- a/docs/reference/quirks/change-polling.md
+++ b/docs/reference/quirks/change-polling.md
@@ -149,7 +149,7 @@ undocumented; confirm the ordering on your deployment before trusting `max(id)+1
 **How to handle:** Sweep with a keyset cursor and **advance by `max(returned id) + 1`**, exactly as for
 `GET bibs`. Always `DELETE` the generated file each page — they accumulate server-side otherwise. Stop
 on a short/empty page, not on a count. For the full recipe (missing-id discovery, the GET/GET/DELETE
-dance, throughput, and orphan handling) see the *Bulk-export the full MARC catalog* how-to.
+dance, throughput, and orphan handling) see the [Bulk-export the full MARC catalog](../../how-to/bulk-export-marc.md) how-to.
 
 ```python
 cursor, MAX = lowest_id, 9_999_999

--- a/docs/reference/quirks/index.md
+++ b/docs/reference/quirks/index.md
@@ -16,7 +16,7 @@ Every quirk is a card with the same four lines:
 !!! warning "Verify on your own deployment"
     These behaviors were observed on specific Sierra deployments (production and test). Versions and
     configuration differ between libraries. Treat each entry as a strong hypothesis to confirm on
-    *your* system — and see [Discover quirks yourself](#discovering-quirks-yourself).
+    *your* system — and see [Discover quirks yourself](../../explanation/discover-quirks-yourself.md).
 
 !!! note "Provenance: patron-record heavy (bib/harvest coverage growing)"
     Most of the write/side-effect knowledge came from patron-record projects, so the catalog still
@@ -53,14 +53,6 @@ Every quirk is a card with the same four lines:
 
 ## Discovering quirks yourself
 
-You don't have to take these on faith. The safe way to confirm a behavior on your own deployment:
-
-- Test against a **test/sandbox Sierra** if you have one, or pick clearly **inactive** records.
-- Probe with **identical-data** PUTs (send a record's data back unchanged) and **intentionally
-  malformed** PUTs — both let you observe side effects without meaningfully altering data.
-- **Hash the content fields** before and after to prove the payload is unchanged while you watch
-  what Sierra mutates on its own.
-- Cross-check against the database (read-only) if you have SQL access.
-
-A runnable, deployment-agnostic version of this probe harness is planned for a later phase of this
-guide.
+You don't have to take these on faith — every entry is a hypothesis you can confirm on
+your own deployment with safe, read-mostly probes. See
+[Discovering quirks yourself](../../explanation/discover-quirks-yourself.md) for the method.

--- a/docs/reference/quirks/side-effects.md
+++ b/docs/reference/quirks/side-effects.md
@@ -22,7 +22,7 @@ The CIRCACTIVE bump is the consequential one: Sierra treats *any* patron PUT as 
 **How to handle:** Assume every PUT moves all four. Any retention/purge/dormancy workflow keyed on
 `activity_gmt` (CIRCACTIVE), Updated Date, Revisions, or PDATE will see touched records as "recently
 active." If that matters, skip records you'd rather not bump, or accept the bump knowingly. Exclude
-these four keys from any "did anything else change?" verification.
+these four keys from any "did anything else change?" verification. See [Why writes have side effects](../../explanation/sierra-rest-thin-projection.md) for why an identical PUT still moves them.
 
 **How we know:** A round-trip test (GET → PUT identical data → GET) showed identical content hashes
 before and after, but all four timestamps/counters had moved; reconfirmed across thousands of PUTs
@@ -51,7 +51,7 @@ by **1** per Sierra Desktop staff save.
 
 **How to handle:** Use it as a rough forensic signal when auditing record history: a `+2` Revisions
 delta suggests a REST API touch, `+1` suggests a Desktop save. It's a first cut, not proof — a
-coincidence could produce either.
+coincidence could produce either. See [Why writes have side effects](../../explanation/sierra-rest-thin-projection.md) (a REST PUT is effectively two saves).
 
 **How we know:** REST PUTs were observed moving the counter by 2 (e.g. 42 → 44) while an
 empirical Desktop edit moved it by exactly 1. The likely cause is that a REST PUT performs two

--- a/docs/reference/quirks/write-semantics.md
+++ b/docs/reference/quirks/write-semantics.md
@@ -40,6 +40,8 @@ varfields = record.get("varFields", [])
 client.request("PUT", f"patrons/{record_num}", json={"varFields": varfields})
 ```
 
+For the full safe-write procedure, see [Safely edit a record (GET-modify-PUT)](../../how-to/safe-get-modify-put.md).
+
 **How we know:** Confirmed repeatedly across large patron cleanups, and re-confirmed with a
 controlled sentinel probe (append a known marker, verify, then PUT the originals back to remove it).
 

--- a/docs/reference/quirks/write-semantics.md
+++ b/docs/reference/quirks/write-semantics.md
@@ -121,7 +121,7 @@ the underlying `varFields` and **re-renders** them after every `varFields` PUT.
 
 **How to handle:** Don't compare these top-level arrays before/after a write to detect "did something
 else change?" — they shift on every legitimate varField edit. Compare the underlying varFields
-instead.
+instead. See [Why writes have side effects](../../explanation/sierra-rest-thin-projection.md) for the underlying reason.
 
 **How we know:** Equality checks on these arrays false-positived on every successful varField edit
 during pilot runs; switching the check to the underlying varFields resolved it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - Recipes:
       - Safely edit a record (GET-modify-PUT): how-to/safe-get-modify-put.md
       - Bulk-export the full MARC catalog: how-to/bulk-export-marc.md
+      - Poll for changed and deleted records: how-to/poll-for-changes.md
   - Reference:
       - The Quirks Catalog:
           - Overview: reference/quirks/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,3 +57,5 @@ nav:
           - Side effects: reference/quirks/side-effects.md
           - Reads & IDs: reference/quirks/reads-and-ids.md
           - Change polling, ranges & pagination: reference/quirks/change-polling.md
+  - Explanation:
+      - Why writes have side effects: explanation/sierra-rest-thin-projection.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
   - Get Started:
       - Your first API call: tutorials/getting-started.md
   - Recipes:
+      - Safely edit a record (GET-modify-PUT): how-to/safe-get-modify-put.md
       - Bulk-export the full MARC catalog: how-to/bulk-export-marc.md
   - Reference:
       - The Quirks Catalog:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,3 +59,4 @@ nav:
           - Change polling, ranges & pagination: reference/quirks/change-polling.md
   - Explanation:
       - Why writes have side effects: explanation/sierra-rest-thin-projection.md
+      - Discovering quirks yourself: explanation/discover-quirks-yourself.md


### PR DESCRIPTION
Resolves the gating Diátaxis decision deferred from Phase 1 and ships the prose that earns its own page.

## The decision
The Quirks Catalog cards (Behavior · Type · How to handle · How we know) stay as a **sanctioned Reference "field-notes" genre** — Diátaxis-faithful via terse pointers, *not* decomposed into fragments. Going-forward discipline is a **graduation rule**: only multi-step tasks graduate to How-to, only shared root-cause models graduate to Explanation, everything else stays an inline card line.

Spec & plan live in the maintainer's notes repo (not public): `2026-06-20-sierra-ils-utils-docs-phase-2a-design.md` / `-phase-2a.md`.

## What's in this PR
- **Explanation (new):** `explanation/sierra-rest-thin-projection.md` — the one root-cause model behind derived projections, PUT-as-two-saves, the +2 revisions counter, and the four housekeeping timestamp bumps. The cards that share that cause now link to it.
- **Explanation (relocated):** `explanation/discover-quirks-yourself.md` — the empirical methodology moved out of the reference index (which was the one clear Phase-1 quadrant misplacement); the index links to it.
- **Recipe (new):** `how-to/safe-get-modify-put.md` — the textbook GET (`fields=,`) → modify varFields → PUT complete array → check 204 / skip 404, carrying the read-only-fields and empty-content gotchas as steps.
- **Recipe (new):** `how-to/poll-for-changes.md` — windowed keyset change poll + separate day-granular deletion poll + reconcile.
- **Recipe (verified):** `how-to/bulk-export-marc.md` — confirmed correct against the reference cards; made the bibs/marc back-link live.
- **Cross-links:** graduated cards gained outbound "→ recipe / → why" links; cards otherwise untouched (inline content preserved).
- **CI:** bumped Node-20-deprecated Actions (`checkout@v7`, `setup-uv@v7`, `upload-pages-artifact@v5`, `deploy-pages@v5`) — all tags verified to exist.

## Verification
- `mkdocs build --strict` — pass (no broken links/anchors)
- `scripts/check-docs-clean.sh docs` — pass (leak-lint)
- Package tests — 41/41 pass (untouched)
- Built subagent-per-task with per-task reviews + a final whole-branch review (ready-to-merge, 0 Critical/Important).

**Note:** the Actions bump only validates on the first post-merge Docs workflow run — worth a glance to confirm no Node-20 deprecation warning remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)