### PR TITLE
docs(quirks): add scoped records (campus_code) page

### DIFF
--- a/docs/reference/quirks/index.md
+++ b/docs/reference/quirks/index.md
@@ -50,6 +50,9 @@ Every quirk is a card with the same four lines:
 | `updatedDate` + `id` range filters AND together in one query | By design | [Change polling](change-polling.md) |
 | List responses cap at ~2000; detect end by a short page, not `total` | By design | [Change polling](change-polling.md) |
 | `deleted=false` hides server-deleted records (they vanish from polls) | By design | [Change polling](change-polling.md) |
+| `suppressed` is a read-only boolean on bibs and items | By design | [Suppression](suppression.md) |
+| `suppressed=true` filters; suppressed records are otherwise returned inline | By design | [Suppression](suppression.md) |
+| Suppression rides in the MARC export — bib `998$e`, item `945$o` | By design | [Suppression](suppression.md) |
 
 ## Discovering quirks yourself
 

--- a/docs/reference/quirks/index.md
+++ b/docs/reference/quirks/index.md
@@ -53,6 +53,8 @@ Every quirk is a card with the same four lines:
 | `suppressed` is a read-only boolean on bibs and items | By design | [Suppression](suppression.md) |
 | `suppressed=true` filters; suppressed records are otherwise returned inline | By design | [Suppression](suppression.md) |
 | Suppression rides in the MARC export — bib `998$e`, item `945$o` | By design | [Suppression](suppression.md) |
+| `items?deleted=false` returns only the host's own (`campus_code=''`) records | By design | [Scoped records](scoped-records.md) |
+| `record_num` is non-unique in `record_metadata` (one row per scope) | By design | [Scoped records](scoped-records.md) |
 
 ## Discovering quirks yourself
 

--- a/docs/reference/quirks/scoped-records.md
+++ b/docs/reference/quirks/scoped-records.md
@@ -1,0 +1,50 @@
+# Scoped records (`campus_code`)
+
+In a shared or consortium Sierra, the database holds records for more than one agency. The REST API
+shows you only the host library's own slice — which surprises you the first time you reconcile an API
+harvest against a raw SQL count.
+
+## `GET items?deleted=false` returns only the host's own records (`campus_code = ''`)
+
+**Behavior:** A full enumeration of `items?deleted=false` returns only the records the host library
+*owns* — the ones whose `sierra_view.record_metadata.campus_code` is the empty string. In a
+multi-agency deployment the same `record_metadata` view (`record_type_code='i'`,
+`deletion_date_gmt IS NULL`) also contains **scoped/virtual item records** for partner agencies under
+*non-blank* `campus_code` values. Those scoped records are **not** returned by the REST items
+endpoint, even though they are non-deleted and look identical to a count over the SQL view. The same
+applies to the other record types that participate in scoping.
+
+This is also why `record_num` is **not unique** in `record_metadata`: one record number can appear once
+per scope (the host's blank-campus row plus one row per agency that has a scoped copy), so a naive
+`COUNT(*)` over the view over-counts relative to `COUNT(DISTINCT record_num)`, and *both* over-count
+relative to what REST returns.
+
+**Type:** By design (the REST API is scoped to the host record set).
+
+**How to handle:** When you reconcile a REST item (or bib) harvest against the SQL views, filter the
+SQL side to `campus_code = ''` before comparing — otherwise you will chase a phantom gap. Compare
+**sets, not counts**: anti-join distinct API `id` against distinct `record_num`, because the SQL-side
+`record_num` non-uniqueness and the `record_metadata → item_record` join fan-out both inflate any
+count-based decomposition. Don't expect REST to expose partner-agency scoped records at all; if you
+need them, they come from SQL (or possibly a per-`id` `GET items/{record_num}` — confirm on your
+deployment). Scoped record numbers can fall **outside** the host's own record-number range, so a
+range/keyset walk of the host scope will never reach them — that is correct, not a truncation bug.
+
+```sql
+-- The REST items?deleted=false universe == the host's own (blank-campus) records:
+SELECT count(DISTINCT record_num)
+FROM sierra_view.record_metadata
+WHERE record_type_code = 'i'
+  AND deletion_date_gmt IS NULL
+  AND campus_code = '';     -- omit this line and the count will exceed what REST returns
+```
+
+**How we know:** On one production consortium deployment, a complete keyset harvest of
+`items?deleted=false` captured **4,815,679** item records. The SQL view had **5,185,806** distinct
+non-deleted type-`i` `record_num`s — ~370k (~7%) more. A set anti-join (not counts) settled it: every
+captured record existed in SQL (`bronze − SQL = 0`), the entire 370,127-record gap was **non-blank
+`campus_code`** (≈200 partner agencies), and the distinct `record_num` count for `campus_code = ''`
+was **4,815,679 — exactly equal, to the record, to the REST capture.** The gap records spanned record
+numbers from `5` to `38,419,702`, well outside the host's own `1,000,002–13,194,349` item-number
+range. Suppression was ruled out separately (suppressed host records *are* returned inline — see
+[Suppression](suppression.md)); the axis was scope, not suppression.

--- a/docs/reference/quirks/suppression.md
+++ b/docs/reference/quirks/suppression.md
@@ -53,9 +53,9 @@ harvest already carries suppression — no separate JSON fetch is required to ca
 suppression for free, in the same pass — and to backfill it from already-stored MARC with zero new
 API calls. **Store the raw code, not a hard-coded boolean** — and **do not assume `'s'` is the only
 suppressed code.** The reliable rule is the *inverse*: `'-'` is the OPAC-display (not-suppressed)
-value, and **any other code is suppressed** (`suppressed = code != '-'`). At CHPL, BOTH `'s'` and
-`'d'` occur and both map to REST `suppressed=true` (the `'s'`-only assumption from a test-environment
-sample missed the `'d'`, which only appeared in production data). So keep the raw code in the lake
+value, and **any other code is suppressed** (`suppressed = code != '-'`). On one production deployment,
+BOTH `'s'` and `'d'` occur and both map to REST `suppressed=true` (the `'s'`-only assumption from a
+test-environment sample missed the `'d'`, which only appeared in production data). So keep the raw code in the lake
 and apply `coalesce(code,'-') <> '-'` (or `NOT IN (<your library's display code>)`) downstream;
 that survives codes you haven't enumerated yet. Confirm your deployment's display code by correlating
 the fixed-field value against the REST `suppressed` boolean across a varied sample, **including a

--- a/docs/reference/quirks/suppression.md
+++ b/docs/reference/quirks/suppression.md
@@ -1,0 +1,92 @@
+# Suppression (`suppressed`, BCODE3 / ICODE2)
+
+How Sierra exposes OPAC suppression across the REST API and the MARC export. Suppression is **not
+deletion** — a suppressed record is live and fully retrievable; it is merely hidden from the public
+discovery layer. If you are building a patron-facing slice, this is the flag you filter on.
+
+## `suppressed` is a read-only boolean on bibs and items
+
+**Behavior:** `GET bibs?fields=id,suppressed` and `GET items?fields=id,suppressed` both return a
+boolean `suppressed` on every record (e.g. `{"id": "1000165", "suppressed": true}`). It is a
+*computed reflection* of an underlying fixed field (below), not an independently writable field — it
+appears in the API's list of PUT-rejected read-only fields (see [Write semantics](write-semantics.md)).
+
+**Type:** By design.
+
+**How to handle:** Read it freely to know a record's discovery visibility. To *change* suppression,
+edit the underlying fixed field (BCODE3 for bibs, ICODE2 for items), not `suppressed`.
+
+**How we know:** Live read-only probes on sierra-test (`v6`), 2026-06-21: both endpoints returned
+the boolean; `suppressed` is also enumerated among the read-only top-level fields rejected on PUT.
+
+## `suppressed=true` is a valid filter param on both endpoints
+
+**Behavior:** `GET bibs?suppressed=true&fields=id,suppressed` (and the `items` equivalent) returns
+**only** suppressed records — the symmetric counterpart to `deleted=true&deletedDate=...` for
+deletions. Suppressed records are otherwise **included by default**: a plain `deleted=false` query,
+and the MARC export, both return suppressed records inline (suppression does not hide a record from
+queries the way deletion does).
+
+**Type:** By design.
+
+**How to handle:** Use `suppressed=true` to enumerate the suppressed set directly, or request the
+`suppressed` field on a normal sweep and filter client-side. Do **not** assume a normal harvest
+excludes suppressed records — it doesn't; you simply can't tell which are suppressed unless you ask
+for the field (or read the MARC fixed-field below).
+
+**How we know:** Probes on sierra-test, 2026-06-21: `suppressed=true` returned all-suppressed pages
+on both `bibs` and `items`; a default `deleted=false` window contained `suppressed:true` records
+inline.
+
+## Suppression is carried in the MARC export — bib `998$e` (BCODE3), item `945$o` (ICODE2)
+
+**Behavior:** The boolean is computed from a Sierra fixed field — **BCODE3** ("Suppress (BCODE3)")
+for bibs, **ICODE2** ("Suppress (ICODE2)") for items. Critically, those fixed fields are **present in
+the MARC export** Sierra generates via `bibs/marc`: BCODE3 lands in **`998$e`** and ICODE2 in
+**`945$o`** (the 945 item-data field). On the deployment observed, the suppressed value is `'s'` and
+the unsuppressed value is `'-'`, correlating 1:1 with the REST `suppressed` boolean. So a MARC-based
+harvest already carries suppression — no separate JSON fetch is required to capture it.
+
+**Type:** By design.
+
+**How to handle:** If you harvest MARC, extract `998$e` (bib) and `945$o` (item) to capture
+suppression for free, in the same pass — and to backfill it from already-stored MARC with zero new
+API calls. **Store the raw code, not a hard-coded boolean** — and **do not assume `'s'` is the only
+suppressed code.** The reliable rule is the *inverse*: `'-'` is the OPAC-display (not-suppressed)
+value, and **any other code is suppressed** (`suppressed = code != '-'`). At CHPL, BOTH `'s'` and
+`'d'` occur and both map to REST `suppressed=true` (the `'s'`-only assumption from a test-environment
+sample missed the `'d'`, which only appeared in production data). So keep the raw code in the lake
+and apply `coalesce(code,'-') <> '-'` (or `NOT IN (<your library's display code>)`) downstream;
+that survives codes you haven't enumerated yet. Confirm your deployment's display code by correlating
+the fixed-field value against the REST `suppressed` boolean across a varied sample, **including a
+full-corpus pass** — rare codes hide in the long tail.
+
+**How we know:** sierra-test `v6`, 2026-06-21, via the two-phase `bibs/marc` export used by a
+production harvest. A known-suppressed bib (`.b1000165`, BCODE3=`s`, REST `suppressed=true`) had
+`998$e='s'`; four unsuppressed bibs in the same page had `998$e='-'`. A known-suppressed item
+(ICODE2=`s`, REST `suppressed=true`) had `945$o='s'`; an unsuppressed item on the same bib had
+`945$o='-'`. The per-record `GET bibs/{id}/marc` endpoint returned `400` on this version — MARC is
+available only through the two-phase batch export. **Full-corpus confirmation:** a complete MARC
+re-parse of ~2.08M prod bibs + ~4.65M items found `998$e` ∈ {`-`: 2,080,029; `s`: 12,079; `d`: 1}
+and `945$o` ∈ {`-`; `s`: 464,229} — the single `d` bib (3947502) returned REST `suppressed=true`,
+confirming the `!= '-'` rule and that a test-only sample under-counts the code set.
+
+## Does toggling suppression bump `updatedDate`?
+
+**Behavior:** Because `suppressed` reflects a fixed field, an interactive suppress toggle is a
+record edit and bumps `updatedDate` — so a normal change poll re-fetches the record and a MARC
+harvest re-captures `998$e`/`945$o`. The standing caveat is **batch fixed-field updates** (Sierra
+Global Update), a known class that *may* alter the fixed field without bumping `updatedDate`; not
+specifically confirmed for suppression.
+
+**Type:** By design (with a batch-op residual).
+
+**How to handle:** Rely on the change poll for interactive toggles. Cover the batch-op residual with
+a periodic id/field reconciliation — a cheap `fields=id,suppressed` re-sweep compared against your
+stored value — the same reconcile the [Change polling](change-polling.md) page prescribes for
+deletions. A one-time baseline (re-derive from stored MARC, or one `fields=id,suppressed` sweep)
+seeds the column.
+
+**How we know:** Design-resolved from the fixed-field semantics above plus the API's read-only
+treatment of `suppressed`; the batch-op exception is the documented Global-Update behavior, flagged
+here as an unverified residual to reconcile against rather than a confirmed bump.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
           - Side effects: reference/quirks/side-effects.md
           - Reads & IDs: reference/quirks/reads-and-ids.md
           - Change polling, ranges & pagination: reference/quirks/change-polling.md
+          - Suppression (BCODE3 / ICODE2): reference/quirks/suppression.md
   - Explanation:
       - Why writes have side effects: explanation/sierra-rest-thin-projection.md
       - Discovering quirks yourself: explanation/discover-quirks-yourself.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
           - Reads & IDs: reference/quirks/reads-and-ids.md
           - Change polling, ranges & pagination: reference/quirks/change-polling.md
           - Suppression (BCODE3 / ICODE2): reference/quirks/suppression.md
+          - Scoped records (campus_code): reference/quirks/scoped-records.md
   - Explanation:
       - Why writes have side effects: explanation/sierra-rest-thin-projection.md
       - Discovering quirks yourself: explanation/discover-quirks-yourself.md


### PR DESCRIPTION
## What

Adds a new quirks page **Scoped records (`campus_code`)** documenting that the REST items endpoint (`items?deleted=false`) returns **only the host library's own records** — those with `record_metadata.campus_code = ''`. In a shared/consortium Sierra, scoped/virtual item records for partner agencies (non-blank `campus_code`) are **not** exposed by REST, even though they are non-deleted in the SQL view. Also documents why `record_num` is non-unique in `record_metadata` (one row per scope).

## Evidence

Confirmed on a production consortium deployment via a **set anti-join** (not counts):

- Full keyset harvest of `items?deleted=false` = **4,815,679** records.
- SQL distinct `record_num` (type `i`, not deleted) = **5,185,806** → ~370k more.
- `campus_code=''` distinct `record_num` = **4,815,679 — exactly equal** to the REST capture.
- The 370,127-record gap was **100% non-blank `campus_code`** (~200 partner agencies), spanning record numbers outside the host's own item-number range.
- Suppression ruled out separately (suppressed host records *are* returned inline).

## Changes

- `docs/reference/quirks/scoped-records.md` (new)
- `docs/reference/quirks/index.md` — two quick-reference rows
- `mkdocs.yml` — nav entry

`uv run mkdocs build --strict` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)